### PR TITLE
fix: set APScheduler misfire_grace_time=None for reliable job execution

### DIFF
--- a/src/scheduler/scheduler.py
+++ b/src/scheduler/scheduler.py
@@ -32,7 +32,12 @@ class JobScheduler:
         self.event_bus = event_bus
         self.db_manager = db_manager
         self.default_working_directory = default_working_directory
-        self._scheduler = AsyncIOScheduler()
+        self._scheduler = AsyncIOScheduler(
+            job_defaults={
+                "misfire_grace_time": None,  # Always run, no matter how late
+                "coalesce": True,            # Merge multiple missed runs into one
+            }
+        )
 
     async def start(self) -> None:
         """Load persisted jobs and start the scheduler."""

--- a/tests/unit/test_scheduler/test_misfire_config.py
+++ b/tests/unit/test_scheduler/test_misfire_config.py
@@ -1,0 +1,37 @@
+"""Tests for scheduler misfire configuration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.events.bus import EventBus
+from src.scheduler.scheduler import JobScheduler
+from src.storage.database import DatabaseManager
+
+
+class TestSchedulerMisfireConfig:
+    """Verify APScheduler is configured for resilient job execution."""
+
+    @pytest.fixture
+    def scheduler(self, tmp_path):
+        event_bus = EventBus()
+        db_manager = MagicMock(spec=DatabaseManager)
+        return JobScheduler(
+            event_bus=event_bus,
+            db_manager=db_manager,
+            default_working_directory=tmp_path,
+        )
+
+    def test_misfire_grace_time_is_none(self, scheduler):
+        """misfire_grace_time=None ensures jobs always run, no matter how late."""
+        job_defaults = scheduler._scheduler._job_defaults
+        assert job_defaults.get("misfire_grace_time") is None, (
+            "misfire_grace_time must be None to guarantee late jobs still fire"
+        )
+
+    def test_coalesce_is_enabled(self, scheduler):
+        """coalesce=True merges multiple missed runs into a single execution."""
+        job_defaults = scheduler._scheduler._job_defaults
+        assert job_defaults.get("coalesce") is True, (
+            "coalesce must be True to prevent spam-firing missed runs"
+        )


### PR DESCRIPTION
## Summary

Fixes #175.

The `AsyncIOScheduler` in `JobScheduler.__init__` is created without explicit `job_defaults`, meaning APScheduler uses its default `misfire_grace_time=1` second. This is too strict for a bot where Claude command execution routinely takes minutes — any job that can't start within 1 second of its scheduled time is silently skipped.

**Changes:**
- Set `misfire_grace_time=None` — guarantees every job fires exactly once, regardless of how late
- Set `coalesce=True` — merges multiple missed runs into a single execution, preventing duplicate firing

The worst case with this configuration is one late run, never a skipped one.

## Tests

2 new tests in `tests/unit/test_scheduler/test_misfire_config.py`:
- `test_misfire_grace_time_is_none` — verifies the config value
- `test_coalesce_is_enabled` — verifies coalesce is on

All existing tests continue to pass.