### PR TITLE
feat: add example custom commands to agentic mode bot menu

### DIFF
--- a/src/bot/orchestrator.py
+++ b/src/bot/orchestrator.py
@@ -461,6 +461,12 @@ class MessageOrchestrator:
                 BotCommand("verbose", "Set output verbosity (0/1/2)"),
                 BotCommand("repo", "List repos / switch workspace"),
                 BotCommand("restart", "Restart the bot"),
+                # Vault commands (forwarded to Claude via _handle_unknown_command)
+                BotCommand("today", "Morning briefing and daily plan"),
+                BotCommand("closeday", "End of day review and reflection"),
+                BotCommand("capture", "Quick capture a thought"),
+                BotCommand("schedule", "Plan your week"),
+                BotCommand("context", "Load context for a topic"),
             ]
             if self.settings.enable_project_threads:
                 commands.append(BotCommand("sync_threads", "Sync project topics"))

--- a/tests/unit/test_orchestrator.py
+++ b/tests/unit/test_orchestrator.py
@@ -156,13 +156,16 @@ def test_agentic_registers_text_document_photo_handlers(agentic_settings, deps):
 
 
 async def test_agentic_bot_commands(agentic_settings, deps):
-    """Agentic mode returns 6 bot commands."""
+    """Agentic mode returns 11 bot commands (6 core + 5 vault)."""
     orchestrator = MessageOrchestrator(agentic_settings, deps)
     commands = await orchestrator.get_bot_commands()
 
-    assert len(commands) == 6
+    assert len(commands) == 11
     cmd_names = [c.command for c in commands]
-    assert cmd_names == ["start", "new", "status", "verbose", "repo", "restart"]
+    assert cmd_names == [
+        "start", "new", "status", "verbose", "repo", "restart",
+        "today", "closeday", "capture", "schedule", "context",
+    ]
 
 
 async def test_classic_bot_commands(classic_settings, deps):
@@ -990,3 +993,34 @@ async def test_bot_suffixed_command_not_forwarded(agentic_settings, deps):
     ) as mock_claude:
         await orchestrator._handle_unknown_command(update, context)
         mock_claude.assert_not_called()
+
+
+# --- Vault commands menu tests ---
+
+VAULT_COMMANDS = {"today", "closeday", "capture", "schedule", "context"}
+
+
+class TestVaultCommandsMenu:
+    """Vault commands appear in the bot menu but pass through to Claude."""
+
+    async def test_vault_commands_in_bot_command_list(self, agentic_settings, deps):
+        """Vault commands appear in the Telegram command menu."""
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+        commands = await orchestrator.get_bot_commands()
+        cmd_names = {c.command for c in commands}
+        assert VAULT_COMMANDS.issubset(cmd_names), (
+            f"Missing vault commands: {VAULT_COMMANDS - cmd_names}"
+        )
+
+    async def test_vault_commands_not_in_known_commands(self, agentic_settings, deps):
+        """Vault commands are NOT in _known_commands so they forward to Claude."""
+        orchestrator = MessageOrchestrator(agentic_settings, deps)
+        # register_handlers populates _known_commands
+        app = MagicMock()
+        app.add_handler = MagicMock()
+        orchestrator.register_handlers(app)
+
+        for cmd in VAULT_COMMANDS:
+            assert cmd not in orchestrator._known_commands, (
+                f"/{cmd} should NOT be a known command — it must pass through to Claude"
+            )


### PR DESCRIPTION
## Summary

Related to #173 and #176.

Adds example user-facing commands to `get_bot_commands()` in agentic mode. These commands are NOT registered as `CommandHandler`s — they appear in Telegram's `/` menu for discoverability but are forwarded to Claude as natural language via `_handle_unknown_command`.

This is a minimal approach — a stepping stone toward the configurable custom commands feature discussed in #173. The current PR hardcodes 5 example commands; a follow-up could make these configurable via environment variable or config file.

**Commands added:**
- `/today` — Morning briefing and daily plan
- `/closeday` — End of day review and reflection
- `/capture` — Quick capture a thought
- `/schedule` — Plan your week
- `/context` — Load context for a topic

**How it works:**
- Commands are added to `get_bot_commands()` only (menu visibility)
- They are NOT added to the `handlers` list in `_register_agentic_handlers`
- Therefore they are NOT in `_known_commands`
- `_handle_unknown_command` (group 10) catches them and forwards to Claude

## Tests

2 new tests + 1 updated test in `tests/unit/test_orchestrator.py`:
- `test_vault_commands_in_bot_command_list` — verifies commands appear in menu
- `test_vault_commands_not_in_known_commands` — verifies they pass through to Claude
- Updated `test_agentic_bot_commands` count from 6 to 11

All existing tests continue to pass.