### PR TITLE
feat: allow image + PDF document uploads through validator

### DIFF
--- a/src/security/validators.py
+++ b/src/security/validators.py
@@ -86,6 +86,19 @@ class SecurityValidator:
         ".vue",
         ".svelte",
         ".lock",
+        # Image formats (document uploads; native photos go through image_handler.py)
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".webp",
+        ".heic",
+        ".heif",
+        ".bmp",
+        ".tiff",
+        ".tif",
+        # Document formats
+        ".pdf",
     }
 
     # Forbidden filenames and patterns


### PR DESCRIPTION
## Summary

`SecurityValidator.ALLOWED_EXTENSIONS` currently permits only source-code file extensions (`.py`, `.js`, `.md`, etc.), so any photo or PDF sent as a Telegram **document** (rather than via the native photo handler) is rejected at validation time — before `FileHandler` can inspect it. This PR adds the common attachment formats so document uploads work end-to-end.

## Why

Telegram delivers media in two ways:

1. **Native photo** — passes through `agentic_photo` → `image_handler.py` → SDK content blocks (multimodal). Already works.
2. **As a document** — passes through `agentic_document` → `validate_filename` → `FileHandler.handle_document_upload`. Currently fails on the validator step for binary formats because `.pdf`, `.png`, `.jpg`, etc. aren't in the allowlist.

Path 2 hits often: users sending PDFs, image attachments from email/web, screenshots saved as files instead of pasted, scanned documents. Today they all bounce with `File type not allowed: .pdf`.

This is also a prerequisite for any feature that expects to consume PDFs/images via the document pathway (e.g. PR #193's unified FileHandler branch).

## What

Adds image + PDF formats to `ALLOWED_EXTENSIONS`:

```python
# Image formats (document uploads; native photos go through image_handler.py)
".png", ".jpg", ".jpeg", ".gif", ".webp",
".heic", ".heif", ".bmp", ".tiff", ".tif",
# Document formats
".pdf",
```

## Compatibility

- Pure addition. Existing allowlist entries unchanged.
- `DANGEROUS_FILE_PATTERNS` (`.exe`, `.key`, `.pem`, `.dll`, `.so`, `.dylib`, etc.) remains the deny-list and is checked **before** the allowlist, so dangerous extensions stay blocked.
- 10MB upload size cap (`max_size` in `agentic_document`) still applies.

## Test plan

- [ ] Send a `.pdf` document — bot accepts (passes validator), routes to `FileHandler`
- [ ] Send a `.png` as a document — bot accepts
- [ ] Send a `.exe` — bot still rejects (dangerous pattern takes precedence)
- [ ] Send a `.key` — bot still rejects
- [ ] Send a `.heic` (iPhone photos sent as documents) — bot accepts

## Notes

This is the minimal fix to unblock binary document uploads. What `FileHandler` actually does with a binary file is a separate concern — that's where #193 picks up. This PR just makes the validator stop being the wall.