### PR TITLE
fix(sdk): pass [] instead of None for allowed/disallowed tools (NoneType crash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ sessions/
 backups/
 uploads/
 config/mcp.json
+# Local env backups (ignored)
+.env.bak
+.env.bak2
+.env.kai

--- a/src/claude/sdk_integration.py
+++ b/src/claude/sdk_integration.py
@@ -309,11 +309,15 @@ class ClaudeSDKManager:
                     path=str(claude_md_path),
                 )
 
-            # When DISABLE_TOOL_VALIDATION=true, pass None for allowed/disallowed
-            # tools so the SDK does not restrict tool usage (e.g. MCP tools).
+            # When DISABLE_TOOL_VALIDATION=true, pass [] (not None) for
+            # allowed/disallowed tools. claude-agent-sdk subprocess_cli.py
+            # calls list(options.allowed_tools) unconditionally and crashes
+            # with "'NoneType' object is not iterable". Empty list is treated
+            # by the CLI as "no --allowedTools flag" → no restriction, which
+            # is the intent of DISABLE_TOOL_VALIDATION=true.
             if self.config.disable_tool_validation:
-                sdk_allowed_tools = None
-                sdk_disallowed_tools = None
+                sdk_allowed_tools = []
+                sdk_disallowed_tools = []
             else:
                 sdk_allowed_tools = self.config.claude_allowed_tools
                 sdk_disallowed_tools = self.config.claude_disallowed_tools


### PR DESCRIPTION
## Problem

When `DISABLE_TOOL_VALIDATION=true` is set, every Telegram message produces `Claude integration failed` and the SDK crashes before the CLI even starts:

```
{"error": "'NoneType' object is not iterable", "error_type": "TypeError",
 "event": "Unexpected error in Claude SDK", "logger": "src.claude.sdk_integration"}
```

## Root cause

`ClaudeSDKManager.run_command` (src/claude/sdk_integration.py:314) passes `None` for `sdk_allowed_tools` / `sdk_disallowed_tools` when `disable_tool_validation` is true.

Downstream, `claude-agent-sdk` (verified on **both 0.1.81 and the latest 0.2.82**) calls `list(self._options.allowed_tools)` unconditionally inside `subprocess_cli.py::_apply_skills_defaults`. `list(None)` → `TypeError`.

This is a real bug in the SDK (no None-guard on a documented-as-optional field), but the fix here is trivial on the Cct side and unblocks every user who enables MCP with `DISABLE_TOOL_VALIDATION=true` (the standard recipe for adding third-party MCP servers like MemPalace, Mem0, etc.).

## Fix

Pass `[]` instead of `None`. The CLI treats an empty list as "no `--allowedTools` flag" → no restriction, which matches the intent of `DISABLE_TOOL_VALIDATION=true`.

```python
if self.config.disable_tool_validation:
    sdk_allowed_tools = []      # was: None
    sdk_disallowed_tools = []   # was: None
```

## Reproduction

1. `.env`: `DISABLE_TOOL_VALIDATION=true` + `ENABLE_MCP=true` + valid `MCP_CONFIG_PATH`
2. Send any message to the bot
3. Without this fix: `Claude integration failed` on every turn
4. With this fix: bot responds normally; MCP tools are accessible

Verified end-to-end with a 27-tool MemPalace MCP server (Python `mempalace-mcp` binary) on `claude-agent-sdk 0.1.81` + Cct 1.6.0.

## Upstream

Will file matching issue/PR upstream at anthropics/claude-agent-sdk-python so the SDK adds `or []` on the `list()` call. Until that lands, this Cct-side guard is the practical fix.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)