### PR TITLE
fix: give the getUpdates client its own connection pool

### DIFF
--- a/src/bot/core.py
+++ b/src/bot/core.py
@@ -64,6 +64,15 @@ class ClaudeCodeBot:
         builder.write_timeout(30)
         builder.pool_timeout(30)
 
+        # Long polling uses a separate HTTP client whose connection pool holds a
+        # single connection by default. If a long-running getUpdates request is
+        # torn down mid-flight (unstable network, proxy or tunnel drop), that
+        # connection can stay checked out, and every later getUpdates call then
+        # fails with "Pool timeout: All connections in the connection pool are
+        # occupied", permanently, even after the network recovers. A small pool
+        # leaves headroom so polling can recover on its own.
+        builder.get_updates_connection_pool_size(8)
+
         # Explicitly set proxy from environment variables.
         # This is necessary because python-telegram-bot's Application.builder()
         # does not automatically use HTTP_PROXY/HTTPS_PROXY environment variables.

--- a/tests/unit/test_bot/test_core_connection_pool.py
+++ b/tests/unit/test_bot/test_core_connection_pool.py
@@ -1,0 +1,56 @@
+"""Tests for bot core HTTP connection pool wiring."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import src.bot.core as core_module
+from src.bot.core import ClaudeCodeBot
+from src.config import create_test_config
+
+
+@pytest.fixture
+def bot_with_builder(monkeypatch):
+    """Create a bot with mocked Application builder plumbing."""
+    settings = create_test_config()
+    deps = {
+        "storage": MagicMock(),
+        "security": MagicMock(),
+    }
+    bot = ClaudeCodeBot(settings, deps)
+
+    builder = MagicMock()
+
+    app = MagicMock()
+    app.bot = MagicMock()
+    app.bot.set_my_commands = AsyncMock()
+    app.initialize = AsyncMock()
+    builder.build.return_value = app
+
+    monkeypatch.setattr(
+        core_module.Application,
+        "builder",
+        MagicMock(return_value=builder),
+    )
+    monkeypatch.setattr(
+        core_module,
+        "FeatureRegistry",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr(bot, "_set_bot_commands", AsyncMock())
+    monkeypatch.setattr(bot, "_register_handlers", MagicMock())
+    monkeypatch.setattr(bot, "_add_middleware", MagicMock())
+
+    return bot, builder
+
+
+@pytest.mark.asyncio
+async def test_initialize_gives_get_updates_client_a_pool(bot_with_builder):
+    """Long polling must not run on the default single-connection pool."""
+    bot, builder = bot_with_builder
+
+    await bot.initialize()
+
+    builder.get_updates_connection_pool_size.assert_called_once()
+    pool_size = builder.get_updates_connection_pool_size.call_args.args[0]
+    assert pool_size > 1


### PR DESCRIPTION
## Description

Long polling in python-telegram-bot uses a separate HTTP client from the one configured in `initialize()`, and its connection pool holds a single connection by default. If a long-running `getUpdates` request is torn down mid-flight, that connection can stay checked out and every later poll fails immediately with `Pool timeout: All connections in the connection pool are occupied` — permanently, even after the network recovers. The process stays alive and the retry loop keeps running, so the bot looks healthy while receiving nothing.

This sets `get_updates_connection_pool_size(8)` so the poller has headroom to recover on its own. Same class of problem as #166, which fixed pool corruption for the main client only.

## Related Issue

Fixes #213 — full analysis and reproduction there.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- `src/bot/core.py`: set `get_updates_connection_pool_size(8)` on the application builder.
- `tests/unit/test_bot/test_core_connection_pool.py`: assert the `getUpdates` client is not left on the default single-connection pool.

## Testing
- [x] Tests added/updated
- [x] All tests pass — `531 passed`
- [x] Manual testing completed

Reproduced deterministically by severing the connection to the upstream mid-`getUpdates` for ~60s and then restoring it. Before: ~60 `Pool timeout` errors per minute after restore, zero successful requests, `CLOSE_WAIT` socket persisting. After: three consecutive cycles, polling recovers each time, no `CLOSE_WAIT` accumulation.

The new test fails on `main` and passes with the fix.

## Checklist
- [x] `make format` has been run (black, isort, flake8 clean)
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated — not applicable
- [x] No breaking changes
